### PR TITLE
Improve basic functions and extend readme example

### DIFF
--- a/metoppy/metopreader.py
+++ b/metoppy/metopreader.py
@@ -25,8 +25,7 @@ class MetopReader:
         # Import Julia package installed via juliapkg.json
         Main.seval("import MetopDatasets")
         # Store module and commonly used functions
-        self._keys = Main.MetopDatasets.keys
-        self._load_dataset = Main.MetopDatasets.MetopDataset
+        self._open_dataset = Main.MetopDatasets.MetopDataset
         self._get_test_data_artifact = Main.MetopDatasets.get_test_data_artifact
 
     def get_keys(self, dataset):
@@ -43,27 +42,79 @@ class MetopReader:
         list
             The list of keys available in the dataset.
         """
-        return self._keys(dataset)
-
-    def load_dataset(self, file_path: str):
+        return Main.keys(dataset)
+    
+    def as_array(self, variable):
         """
-        Load a dataset from a record path using MetopDatasets.MetopDataset.
+        Load the variable as a Julia array.
+
+        Parameters
+        ----------
+        variable : Julia object
+            A variable from a MetopDatasets.MetopDataset object.
+
+        Returns
+        -------
+        Julia array
+            The data from the variable loaded as an array.
+        """
+        return Main.Array(variable)
+    
+    def shape(self, variable_or_j_array):
+        """
+        Get the shape a Julia array or variable.
+
+        Parameters
+        ----------
+        variable_or_j_array : Julia object
+            A variable from a MetopDatasets.MetopDataset object or a Julia Array.
+
+        Returns
+        -------
+        Tuple of ints
+            The shape of the variable
+        """
+        return Main.size(variable_or_j_array)
+
+    def open_dataset(self, file_path: str, maskingvalue = Main.missing):
+        """
+        Open a dataset from a record path using MetopDatasets.MetopDataset.
 
         Parameters
         ----------
         file_path : str
             Path to the dataset record.
 
+        maskingvalue
+            The masking values are used to replace missing observations. Defaults to Julia Missing type. 
+            A recommended alternative is float("nan") which increasse performance for float data.
+
         Returns
         -------
         Julia object
-            A MetopDataset object loaded from the provided path.
+            A MetopDataset object opened from the provided path.
         """
         try:
-            return self._load_dataset(file_path)
+            return self._open_dataset(file_path, maskingvalue = maskingvalue)
         except Exception as e:
-            raise RuntimeError(f"Failed to load dataset: {file_path}") from e
+            raise RuntimeError(f"Failed to open dataset: {file_path}") from e
+        
+    def close_dataset(self, dataset):
+        """
+        Close a dataset and free the file lock created by MetopReader.open_dataset
 
+        Parameters
+        ----------
+        dataset : Julia object
+            A dataset object created by MetopDatasets.MetopDataset.
+
+        Returns
+        -------
+        None
+        """
+        Main.close(dataset)
+        return None
+    
     def get_test_data_artifact(self):
         """
         Retrieve the test dataset artifact from MetopDatasets.

--- a/metoppy/tests/test_get_test_data_artifact.py
+++ b/metoppy/tests/test_get_test_data_artifact.py
@@ -12,7 +12,6 @@
 
 # TODO: Convert to pytest
 from pathlib import Path
-from juliacall import Main
 from metoppy.metopreader import MetopReader
 
 metop_reader = MetopReader()
@@ -23,7 +22,7 @@ reduced_data_files = [f for f in reduced_data_folder.iterdir() if f.is_file()]
 
 test_file_name = next((s for s in reduced_data_files if s.name.startswith("ASCA_SZO")))
 test_file_path = reduced_data_folder / test_file_name
-ds = metop_reader.load_dataset(file_path=str(test_file_path))
+ds = metop_reader.open_dataset(file_path=str(test_file_path), maskingvalue = float("nan"))
 
 keys = metop_reader.get_keys(ds)
 print(list(keys))
@@ -31,12 +30,13 @@ print(list(keys))
 print(ds["latitude"])
 
 # Convert CFVariable to a full Julia Array
-latitude_julia = Main.Array(ds["latitude"])  # preserves the 2D shape
+latitude_julia = metop_reader.as_array(ds['latitude'])  # preserves the 2D shape
+latitude_shape = metop_reader.shape(latitude_julia)
 
 # Convert to nested Python list
 latitude_list = [
-    [latitude_julia[i, j] for j in range(latitude_julia.size[1])]
-    for i in range(latitude_julia.size[0])
+    [latitude_julia[i, j] for j in range(latitude_shape[1])]
+    for i in range(latitude_shape[0])
 ]
 
 # Print first 5x5 elements


### PR DESCRIPTION
This PR contains a number of smaller changes.
- Rename `read_dataset` to `open_dataset` since the method just opens the dataset and only reads the necessary meta data.
- Add `maskingvalue` argument to  `open_dataset`. I often put it to NaN in my workflows so users are probably also going to need it.
- Add  `as_array` method so we can remove `from juliacall import Main` from the example.
- Add `close_dataset` method
- Add `shape` method to wrap `Main.size`. The `Main.size` function is much more general in julia compared to directly accessing the  `.size` property of a Julia array. E.g. `Main.size` works for all julia array types and not just the standard one.
- Update README example to include new methods.
- Add a small section with `np.array` to the example.