### PR TITLE
Bump MetopDatasets.jl to 0.2.1

### DIFF
--- a/metoppy/juliapkg.json
+++ b/metoppy/juliapkg.json
@@ -3,7 +3,7 @@
   "packages": {
     "MetopDatasets": {
         "uuid": "0c26954c-4046-4b98-a13c-f9377ca4b9b7",
-        "version": "0.2.0"
+        "version": "0.2.1"
     }
   }
 }


### PR DESCRIPTION
See https://github.com/eumetsat/MetopDatasets.jl/releases/tag/v0.2.1 for list of changes.

The update is tested by running the README example skipping the numpy part.