### PR TITLE
CI: Print code coverage in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,4 +22,4 @@ jobs:
           pip install -e .[test]
       - name: Test with pytest
         run: |
-          pytest metoppy/tests --cov=metoppy --cov-report=xml
+          pytest metoppy/tests --cov=metoppy --cov-report=xml --cov-report=term


### PR DESCRIPTION
Print the code coverage to the CI terminal.

Here is the output for the PR
<img width="1268" height="454" alt="image" src="https://github.com/user-attachments/assets/ea98e41b-5f93-47ef-88c4-2e1a474a1f1f" />
