### PR TITLE
chore: 0.1.0 [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/__pycache__/
 dist/
 metoppyenv/
+CHANGELOG_UNRELEASED.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
-# 0.1.0 (2025-??-??)
+# 0.1.0 (2025-11-06)
 
-First release of metoppy package.
+First release of metoppy Python package.
 
 ### Features
 
-- code for v0.1.0
+- CI print code coverage ([#8](https://github.com/eumetsat/MetopPy/pull/8)) ([50052c5](https://github.com/eumetsat/MetopPy/commit/50052c5c8aafaabb9eecca0bd24013b015b91bf3))
+- Add tests with pytest and add github CI action. ([#7](https://github.com/eumetsat/MetopPy/pull/7)) ([7451e0f](https://github.com/eumetsat/MetopPy/commit/7451e0f6d13dba04ccaaa93f3844f8bce1e676c5))
+- Bump MetopDatasets.jl to 0.2.1 ([#6](https://github.com/eumetsat/MetopPy/pull/6)) ([eb670ad](/commit/eb670adaff26a93225880ce68ddfd3801d0e389e))
+- Improve basic functions and extend readme example ([#3](https://github.com/eumetsat/MetopPy/pull/3)) ([99a4b7f](https://github.com/eumetsat/MetopPy/commit/99a4b7f8308d15edc527af3fe595144dd3699163))
+- Migrate from internal Gitlab ([#2](https://github.com/eumetsat/MetopPy/pull/1)) ([0753149](https://github.com/eumetsat/MetopPy/commit/07531490deddc0c0416c1cc6df721ec420e1875c))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,37 +1,60 @@
 # Releasing metoppy
 
-1. checkout main branch
-2. pull from repo
-3. run the unittests
-4. Update the `CHANGELOG.md` file.
-5. Create a tag with the new version number, starting with a 'v', eg:
+0. Make sure the code references the correct new version you want in the pyproject.yaml and in the __init__.py
+1. checkout main branch: `git checkout main`
+2. pull from repo: `git pull`
+3. run the unittests with pytest.
+4. Update the `CHANGELOG.md` file using vim or similar. (`source REPO_URL="https://github.com/eumetsat/MetopPy"`, then `git log --pretty=format:"- %s ([%h]($REPO_URL/commit/%H)) (%an, %ad)" --date=short > CHANGELOG_UNRELEASED.md` You can use `git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"- %s (%h)" > CHANGELOG_UNRELEASED.md` to generate the list of commits and PR used also)
+```
+### Bug Fixes
+* Force ansible roles download when new versions exist ([#22](https://github.com/ewcloud/ewccli/pull/22)) ([#3](https://github.com/ewcloud/ewccli/issues/3)) ([9263391](https://github.com/ewcloud/ewccli/commit/92633917a71d3cf5cf6aea23f4fef83e052f3f92))
+* Remove dependency not used ([#19](https://github.com/ewcloud/ewccli/pull/19)) ([#6](https://github.com/ewcloud/ewccli/issues/6)) ([d44135b](https://github.com/ewcloud/ewccli/commit/d44135bbaf8864722dc324f201d0ad4f61c5a89d))
+```
+5. git add CHANGELOG.md
+6. git commit --cleanup=whitespace # commit title and body to be added. Example below:
+```
+chore: 0.2.0 [skip ci]
+
+# [0.2.0](https://github.com/ewcloud/ewccli/compare/0.1.1...0.2.0) (2025-10-14)
+
+### Features
+
+- feat: Use defaultSecurityGroups and checkDNS from items index [b77b43b](https://github.com/ewcloud/ewccli/commit/b77b43b3916438e476606b58b965712bc08a407d)
+- feat: Introduce checkDNS for items ([#29](https://github.com/ewcloud/ewccli/pull/29)) [7f98a6a](https://github.com/ewcloud/ewccli/commit/7f98a6ab9dcb96825f259663aac8445daaee1b1d)
+- feat: bump versions ([#26](https://github.com/ewcloud/ewccli/pull/26)) [78adb02](https://github.com/ewcloud/ewccli/commit/78adb024771c7a3bc8da83c1325c51a171259557)
+
+### Bug Fixes
+- fix: Set DNS check to 15 minutes [9f24e2f](https://github.com/ewcloud/ewccli/commit/9f24e2f5a7584db980eb0863fc9ab57521536151)
+- fix: ewc hub list command item name should show all name always ([#25](https://github.com/ewcloud/ewccli/pull/25)) [e4869fc](https://github.com/ewcloud/ewccli/commit/e4869fcd4757910160ec68894417fae76ca622b5)
+```
+7. Create a tag with the new version number, eg:
 
    ```
-   git tag -a v<new version> -m "Version <new version>"
+   git tag -a <new version> -m "Version <new version>"
    ```
 
-   For example if the previous tag was `v0.9.0` and the new release is a
+   For example if the previous tag was `0.1.1` and the new release is a
    patch release, do:
 
    ```
-   git tag -a v0.9.1 -m "Version 0.9.1"
+   git tag -a 0.1.1 -m "Version 0.1.1"
    ```
 
    See [semver.org](http://semver.org/) on how to write a version number.
 
-
-6. push changes to github `git push --follow-tags`
-7. Verify github action unittests passed.
-8. Create a "Release" on GitHub by going to
+8. Push commits `git push`
+9. Push tags to github `git push --follow-tags`
+10. Verify github action unittests passed.
+11. Create a "Release" on GitHub by going to
    https://github.com/eumetsat/MetopDatasets.jl/releases and clicking "Draft a new release".
    On the next page enter the newly created tag in the "Tag version" field,
    "Version X.Y.Z" in the "Release title" field, and paste the markdown from
    the changelog (the portion under the version section header) in the
    "Describe this release" box. Finally click "Publish release".
 
-9. Now you can start the process to release on PyPI (only admins)
+12. Now you can start the process to release on PyPI (only admins)
 
-9.1 Build package
+12.1 Build package
 
 Now generate the distribution. To build the package, use PyPA build.
 


### PR DESCRIPTION
### Features

- CI print code coverage ([#8](https://github.com/eumetsat/MetopPy/pull/8)) ([50052c5](https://github.com/eumetsat/MetopPy/commit/50052c5c8aafaabb9eecca0bd24013b015b91bf3))
- Add tests with pytest and add github CI action. ([#7](https://github.com/eumetsat/MetopPy/pull/7)) ([7451e0f](https://github.com/eumetsat/MetopPy/commit/7451e0f6d13dba04ccaaa93f3844f8bce1e676c5))
- Bump MetopDatasets.jl to 0.2.1 ([#6](https://github.com/eumetsat/MetopPy/pull/6)) ([eb670ad](/commit/eb670adaff26a93225880ce68ddfd3801d0e389e))
- Improve basic functions and extend readme example ([#3](https://github.com/eumetsat/MetopPy/pull/3)) ([99a4b7f](https://github.com/eumetsat/MetopPy/commit/99a4b7f8308d15edc527af3fe595144dd3699163))
- Migrate from internal Gitlab ([#2](https://github.com/eumetsat/MetopPy/pull/1)) ([0753149](https://github.com/eumetsat/MetopPy/commit/07531490deddc0c0416c1cc6df721ec420e1875c))