### PR TITLE
Bump MetopDatasets.jl to v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install metoppy
 ## Documentaion
 MetopPy does not yet have its own dedicated documentation page. The best resource for now is the Examples section later in this README.
 
-Another useful resource is the [MetopDatasets.jl documentaion page](https://eumetsat.github.io/MetopDatasets.jl/dev/), which provides concrete examples of how to use the Julia version of the package, supported data formats, and additional information.
+Another useful resource is the [MetopDatasets.jl documentaion page](https://eumetsat.github.io/MetopDatasets.jl/v0.2.2/), which provides concrete examples of how to use the Julia version of the package, supported data formats, and additional information.
 
 ## Dependencies
 

--- a/metoppy/juliapkg.json
+++ b/metoppy/juliapkg.json
@@ -3,7 +3,7 @@
   "packages": {
     "MetopDatasets": {
         "uuid": "0c26954c-4046-4b98-a13c-f9377ca4b9b7",
-        "version": "0.2.1"
+        "version": "0.2.2"
     }
   }
 }


### PR DESCRIPTION
- Bump MetopDatasets.jl to v0.2.2
- Link to MetopDatasets.jl v0.2.2 documentation instead of main branch documentation.